### PR TITLE
fix: fix typo in ethnonym autocomplete endpoint

### DIFF
--- a/archiv/dal_urls.py
+++ b/archiv/dal_urls.py
@@ -19,9 +19,9 @@ urlpatterns = [
         name='schlagwort-autocomplete'
     ),
     path(
-        'ethonym-autocomplete/',
+        'ethnonym-autocomplete/',
         dal_views.Ethnonym.as_view(),
-        name='ethonym-autocomplete'
+        name='ethnonym-autocomplete'
     ),
     path(
         'region-autocomplete/',

--- a/djangobaseproject/urls.py
+++ b/djangobaseproject/urls.py
@@ -23,7 +23,7 @@ router.register(r'cones', archiv_api_views.ConeViewSet, basename='cones-geojson'
 router.register(
     r'lines-and-points',
     archiv_api_views.SpatialCoverageGroupViewSet,
-    basename='ines-and-points'
+    basename='lines-and-points'
 )
 router.register(r'usecase', archiv_api_views.UseCaseViewSet)
 router.register(r'topics', topics_api_views.TopicViewSet)


### PR DESCRIPTION
this fixes a typo in the ethnonym autocomplete endpoint: "ethonym" => "ethnonym"