### PR TITLE
build: add openapi schema view

### DIFF
--- a/djangobaseproject/urls.py
+++ b/djangobaseproject/urls.py
@@ -2,6 +2,7 @@ from django.urls import path, include
 from django.contrib import admin
 from rest_framework import routers
 from rest_framework.documentation import include_docs_urls
+from rest_framework.schemas import get_schema_view
 
 from vocabs import api_views
 from archiv import api_views as archiv_api_views
@@ -53,6 +54,11 @@ urlpatterns = [
     path('vocabs-ac/', include('vocabs.dal_urls', namespace='vocabs-ac')),
     path('', include('webpage.urls', namespace='webpage')),
     path('ckeditor/', include('ckeditor_uploader.urls')),
+    path('openapi', get_schema_view(
+        title="MMP",
+        description="Mapping Medieval Peoples",
+        version="0.1.0"
+    ), name='openapi-schema'),
 ]
 
 


### PR DESCRIPTION
following https://www.django-rest-framework.org/api-guide/schemas/#generating-a-dynamic-schema-with-schemaview this should add a openapi schema endpoint (i think)