### PR TITLE
fix: add missing pyyaml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ django-leaflet
 fontawesome-free==5.15.4
 lxml==4.9.1
 rdflib>=5.0.0,<7
+PyYAML==6.0


### PR DESCRIPTION
follow-up to #128 
this adds the `pyyaml` dependency which is needed by the openapi schema view for serialization