### PR TITLE
fix: use geojson pagination for ort-geojson endpoint

### DIFF
--- a/archiv/api_views.py
+++ b/archiv/api_views.py
@@ -141,6 +141,7 @@ class GeoJsonOrtViewSet(viewsets.ModelViewSet):
         OrderingFilter
     ]
     filter_class = OrtListFilter
+    pagination_class = GeoJsonPagination
 
 
 class FuzzyGeoJsonOrtViewSet(viewsets.ModelViewSet):
@@ -151,6 +152,7 @@ class FuzzyGeoJsonOrtViewSet(viewsets.ModelViewSet):
         OrderingFilter
     ]
     filter_class = OrtListFilter
+    pagination_class = GeoJsonPagination
 
 
 class StelleViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
use geojson pagination for `/api/ort-geojson` and `/api/fuzzy-ort-geojson` endpoints because they return a list of geojson features, not entities. this is consistent with the response payload of the other geojson endpoints. note that this also changes query params from `limit`/`offset` to `page`/`page_size`.

closes #117

before:

![before](https://user-images.githubusercontent.com/20753323/199964934-95b2c0ce-0068-41ea-b466-567f2715a33f.png)

after:

![after](https://user-images.githubusercontent.com/20753323/199964959-1205b962-4279-43c3-b8b4-05cf1f283f22.png)
