### PR TITLE
fix: include BC texts in keyword/century endpoint

### DIFF
--- a/archiv/endpoint_views.py
+++ b/archiv/endpoint_views.py
@@ -83,7 +83,7 @@ def key_word_by_century(request, pk):
     kw = get_object_or_404(KeyWord, pk=pk)
     props = ['id', 'not_before']
     items = Text.objects.filter(
-        rvn_stelle_text_text__key_word=kw, not_before__gte=100, not_after__lte=2000
+        rvn_stelle_text_text__key_word=kw, not_before__gte=-300, not_after__lte=2000
     ).distinct().order_by('not_before').values_list(*props)
     if items:
         df = pd.DataFrame(items, columns=props)

--- a/archiv/endpoint_views.py
+++ b/archiv/endpoint_views.py
@@ -14,7 +14,7 @@ from topics.models import StopWord
 
 
 default = [
-    [x, 0] for x in range(1, 15)
+    [x, 0] for x in range(-3, 16)
 ]
 
 


### PR DESCRIPTION
on http://localhost:8000/archiv/keyword/century/9

before:

![before](https://user-images.githubusercontent.com/20753323/200041365-32740b05-8ed5-42d9-af68-e180f186b435.png)

after:

![after](https://user-images.githubusercontent.com/20753323/200041390-c8e5f014-fc6f-4709-a577-65af3d1be0aa.png)

edit: also update default range to the changes in https://github.com/acdh-oeaw/mmp/commit/82def90d8eab1f83a5adfc7122198891d368beb5

closes #134