### PR TITLE
fix: include antique name in place response, include place type label in place geojson response

### DIFF
--- a/archiv/api_serializers.py
+++ b/archiv/api_serializers.py
@@ -146,6 +146,8 @@ class GeoJsonOrtSerializer(
     GeoFeatureModelSerializer, serializers.ModelSerializer
 ):
 
+    art = serializers.ReadOnlyField(source="kind")
+
     class Meta:
         model = Ort
         geo_field = 'coords'
@@ -159,6 +161,8 @@ class GeoJsonOrtSerializer(
 class FuzzyGeoJsonOrtSerializer(
     GeoFeatureModelSerializer, serializers.ModelSerializer
 ):
+
+    art = serializers.ReadOnlyField(source="kind")
 
     class Meta:
         model = Ort

--- a/archiv/models.py
+++ b/archiv/models.py
@@ -928,6 +928,14 @@ class Ort(models.Model):
                 ])
         return name_list
 
+    @cached_property
+    def kind(self):
+        art = {
+            "id": self.art.id,
+            "label": self.art.pref_label
+        }
+        return art
+
 
 class Stelle(models.Model):
     """ Stelle """

--- a/archiv/models.py
+++ b/archiv/models.py
@@ -861,6 +861,7 @@ class Ort(models.Model):
         pl = {
             "id": self.id,
             "name": self.name,
+            "name_antik": self.name_antik,
             "lat": self.lat,
             "lng": self.long,
             "art": art


### PR DESCRIPTION
this include a place's antique name in /api/place responses, and includes the place type label in /api/place-geojson responses. both are useful for tooltip info client-side.