### PR TITLE
fix: allow casestudy autocomplete, allow empty autocomplete search terms

### DIFF
--- a/djangobaseproject/settings.py
+++ b/djangobaseproject/settings.py
@@ -334,8 +334,8 @@ GENERIC_AC_CONFIG = [
         ]
     },
     {
-        "app_name": 'layers',
-        "model_name": 'geojsonlayer',
+        "app_name": 'archiv',
+        "model_name": 'usecase',
         "search_fields": [
             'title',
         ]

--- a/generic_ac/views.py
+++ b/generic_ac/views.py
@@ -7,11 +7,7 @@ GENERIC_AC_CONFIG = getattr(settings, "GENERIC_AC_CONFIG")
 
 def generic_ac_view(request):
     config = []
-    q = request.GET.get('q')
-    if not len(q) > 2:
-        return JsonResponse({
-            "error": "please add at least 3 letters"
-        })
+    q = request.GET.get('q') or ''
     only_those = request.GET.getlist('kind')
     if only_those:
         for x in GENERIC_AC_CONFIG:

--- a/generic_ac/views.py
+++ b/generic_ac/views.py
@@ -1,25 +1,25 @@
 from django.http import JsonResponse
 from django.conf import settings
-from . utils import query
+from .utils import query
 
 GENERIC_AC_CONFIG = getattr(settings, "GENERIC_AC_CONFIG")
 
 
 def generic_ac_view(request):
     config = []
-    q = request.GET.get('q') or ''
-    only_those = request.GET.getlist('kind')
+    q = request.GET.get("q") or ""
+    only_those = request.GET.getlist("kind")
     if only_those:
         for x in GENERIC_AC_CONFIG:
-            if x['model_name'] in only_those:
+            if x["model_name"] in only_those:
                 config.append(x)
     else:
         config = GENERIC_AC_CONFIG
     data = query(q, config)
     if only_those:
-        data['filter_on'] = only_those
+        data["filter_on"] = only_those
     else:
-        data['filter_on'] = [x['model_name'] for x in GENERIC_AC_CONFIG]
+        data["filter_on"] = [x["model_name"] for x in GENERIC_AC_CONFIG]
 
     return JsonResponse(data, safe=False)
 


### PR DESCRIPTION
this pr adds case studies to the default autocomplete config, and removes geojson layers.

also, removes the restriction to only accept search terms with a min length of 3 - now accepts empty search terms as well.