### PR TITLE
162 add proper pagination for generic autocomplete

### DIFF
--- a/archiv/tests.py
+++ b/archiv/tests.py
@@ -2,6 +2,7 @@ from django.apps import apps
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.urls import reverse
+from archiv.dal_urls import urlpatterns
 from archiv.models import KeyWord, UseCase, Text, Autor, Stelle
 from archiv.utils import parse_date, cent_from_year
 from archiv.text_processing import process_text
@@ -184,3 +185,12 @@ class ArchivTestCase(TestCase):
             item.gnd_id = x[0]
             item.save()
             self.assertEqual(x[1], item.gnd_id)
+
+    def test_016_ac_views(self):
+        ns = 'archiv-ac'
+        for x in urlpatterns:
+            url_name = f"{ns}:{x.name}"
+            url = f"{reverse(url_name)}?q=hansi"
+            response = client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue('results' in response.json().keys())

--- a/archiv/tests.py
+++ b/archiv/tests.py
@@ -150,29 +150,29 @@ class ArchivTestCase(TestCase):
         )
         qs = Stelle.objects.filter(id=stelle.id)
         url = f'{reverse("archiv:nlp_data")}?id={stelle.id}'
-        self.assertEqual(get_nlp_data(qs)['token'][0], 'saruus')
+        self.assertEqual(get_nlp_data(qs)["token"][0], "saruus")
         response = client.get(url).json()
-        self.assertEqual(response['token'][0], 'saruus')
+        self.assertEqual(response["token"][0], "saruus")
 
         StopWord.objects.get_or_create(word="saruus")
-        self.assertEqual(get_nlp_data(qs)['token'][0], 'gens')
+        self.assertEqual(get_nlp_data(qs)["token"][0], "gens")
         response = client.get(url).json()
-        self.assertEqual(response['token'][0], 'gens')
+        self.assertEqual(response["token"][0], "gens")
 
         StopWord.objects.filter(word="saruus").delete()
-        self.assertEqual(get_nlp_data(qs)['token'][0], 'saruus')
+        self.assertEqual(get_nlp_data(qs)["token"][0], "saruus")
         response = client.get(url).json()
-        self.assertEqual(response['token'][0], 'saruus')
+        self.assertEqual(response["token"][0], "saruus")
 
         StopWord.objects.get_or_create(word="sarvus")
-        self.assertEqual(get_nlp_data(qs)['token'][0], 'gens')
+        self.assertEqual(get_nlp_data(qs)["token"][0], "gens")
         response = client.get(url).json()
-        self.assertEqual(response['token'][0], 'gens')
+        self.assertEqual(response["token"][0], "gens")
 
         StopWord.objects.filter(word="sarvus").delete()
-        self.assertEqual(get_nlp_data(qs)['token'][0], 'saruus')
+        self.assertEqual(get_nlp_data(qs)["token"][0], "saruus")
         response = client.get(url).json()
-        self.assertEqual(response['token'][0], 'saruus')
+        self.assertEqual(response["token"][0], "saruus")
 
     def test_015_gnd_normalizer(self):
         gnds = [
@@ -187,10 +187,10 @@ class ArchivTestCase(TestCase):
             self.assertEqual(x[1], item.gnd_id)
 
     def test_016_ac_views(self):
-        ns = 'archiv-ac'
+        ns = "archiv-ac"
         for x in urlpatterns:
             url_name = f"{ns}:{x.name}"
             url = f"{reverse(url_name)}?q=hansi"
             response = client.get(url)
             self.assertEqual(response.status_code, 200)
-            self.assertTrue('results' in response.json().keys())
+            self.assertTrue("results" in response.json().keys())

--- a/archiv/tests_api.py
+++ b/archiv/tests_api.py
@@ -1,9 +1,14 @@
 from django.test import TestCase, Client
+from django.urls import reverse
+from django.conf import settings
+from generic_ac.urls import urlpatterns
 
 
 client = Client()
 
 API_ROOT = '/api/?format=json'
+GN_AC_NS = 'generic-ac'
+GN_AC_CONF = settings.GENERIC_AC_CONFIG
 
 
 class ApiTestCase(TestCase):
@@ -20,3 +25,39 @@ class ApiTestCase(TestCase):
             r = client.get(value)
             self.assertEqual(r.status_code, 200)
             self.assertEqual(r.accepted_media_type, 'application/json')
+
+    def test_003_generic_ac(self):
+        for x in urlpatterns:
+            url_name = f"{GN_AC_NS}:{x.name}"
+            url = f"{reverse(url_name)}?q=obi"
+            response = client.get(url)
+            self.assertEqual(response.status_code, 200)
+
+    def test_004_generic_ac_only_those(self):
+        url_name = f"{GN_AC_NS}:describe"
+        url = f"{reverse(url_name)}"
+        response = client.get(url)
+        self.assertEqual(response.json(), GN_AC_CONF)
+        self.assertEqual(response.status_code, 200)
+
+    def test_005_generic_ac_only_those(self):
+        url_name = f"{GN_AC_NS}:generic_ac"
+        url = f"{reverse(url_name)}?kind=autor&limit=100&page=1"
+        response = client.get(url)
+        authors = int(response.json()['count'])
+        url = f"{reverse(url_name)}?limit=100"
+        response = client.get(url)
+        all_kinds = int(response.json()['count'])
+        self.assertTrue(authors < all_kinds)
+        url = f"{reverse(url_name)}?limit=1"
+        response = client.get(url)
+        self.assertTrue(response.json()['next'])
+        url = f"{reverse(url_name)}?limit=1&page=2"
+        response = client.get(url)
+        self.assertTrue(response.json()['previous'])
+        url = f"{reverse(url_name)}?limit=1&page=2&q=sadlfjsalöfjlsdafjsdlkfj"
+        response = client.get(url)
+        self.assertEqual(int(response.json()['count']), 0)
+        url = f"{reverse(url_name)}?limit=hansi&page=sumsi"
+        response = client.get(url)
+        self.assertTrue(int(response.json()['count']))

--- a/archiv/tests_api.py
+++ b/archiv/tests_api.py
@@ -6,8 +6,8 @@ from generic_ac.urls import urlpatterns
 
 client = Client()
 
-API_ROOT = '/api/?format=json'
-GN_AC_NS = 'generic-ac'
+API_ROOT = "/api/?format=json"
+GN_AC_NS = "generic-ac"
 GN_AC_CONF = settings.GENERIC_AC_CONFIG
 
 
@@ -17,14 +17,14 @@ class ApiTestCase(TestCase):
     def test_001_api_endpoint(self):
         r = client.get(API_ROOT)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.accepted_media_type, 'application/json')
+        self.assertEqual(r.accepted_media_type, "application/json")
 
     def test_002_model_endpoints(self):
         endpoints = client.get(API_ROOT).json()
         for _, value in endpoints.items():
             r = client.get(value)
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.accepted_media_type, 'application/json')
+            self.assertEqual(r.accepted_media_type, "application/json")
 
     def test_003_generic_ac(self):
         for x in urlpatterns:
@@ -44,20 +44,20 @@ class ApiTestCase(TestCase):
         url_name = f"{GN_AC_NS}:generic_ac"
         url = f"{reverse(url_name)}?kind=autor&limit=100&page=1"
         response = client.get(url)
-        authors = int(response.json()['count'])
+        authors = int(response.json()["count"])
         url = f"{reverse(url_name)}?limit=100"
         response = client.get(url)
-        all_kinds = int(response.json()['count'])
+        all_kinds = int(response.json()["count"])
         self.assertTrue(authors < all_kinds)
         url = f"{reverse(url_name)}?limit=1"
         response = client.get(url)
-        self.assertTrue(response.json()['next'])
+        self.assertTrue(response.json()["next"])
         url = f"{reverse(url_name)}?limit=1&page=2"
         response = client.get(url)
-        self.assertTrue(response.json()['previous'])
+        self.assertTrue(response.json()["previous"])
         url = f"{reverse(url_name)}?limit=1&page=2&q=sadlfjsalöfjlsdafjsdlkfj"
         response = client.get(url)
-        self.assertEqual(int(response.json()['count']), 0)
+        self.assertEqual(int(response.json()["count"]), 0)
         url = f"{reverse(url_name)}?limit=hansi&page=sumsi"
         response = client.get(url)
-        self.assertTrue(int(response.json()['count']))
+        self.assertTrue(int(response.json()["count"]))

--- a/generic_ac/utils.py
+++ b/generic_ac/utils.py
@@ -4,20 +4,15 @@ from django.db.models import Q
 
 def query(q, config):
     counter = 0
-    response = {
-        "q": q,
-        "next": None,
-        "previous": None,
-        "results": []
-    }
+    response = {"q": q, "next": None, "previous": None, "results": []}
     for x in config:
         or_condition = Q()
-        app_name = x['app_name'].lower()
-        model_name = x['model_name'].lower()
+        app_name = x["app_name"].lower()
+        model_name = x["model_name"].lower()
         model = ContentType.objects.get(
             app_label=app_name, model=model_name
         ).model_class()
-        for search_field in x['search_fields']:
+        for search_field in x["search_fields"]:
             or_condition.add(Q(**{f"{search_field}__icontains": q}), Q.OR)
         for obj in model.objects.filter(or_condition).distinct():
             counter += 1
@@ -28,9 +23,9 @@ def query(q, config):
                 "label": obj.__str__(),
             }
             try:
-                item['url'] = obj.get_absolute_url()
+                item["url"] = obj.get_absolute_url()
             except AttributeError:
-                item['url'] = None
-            response['results'].append(item)
-    response['count'] = counter
+                item["url"] = None
+            response["results"].append(item)
+    response["count"] = counter
     return response

--- a/generic_ac/utils.py
+++ b/generic_ac/utils.py
@@ -1,10 +1,11 @@
 from django.contrib.contenttypes.models import ContentType
+from django.core.paginator import Paginator, EmptyPage
 from django.db.models import Q
 
 
-def query(q, config):
-    counter = 0
-    response = {"q": q, "next": None, "previous": None, "results": []}
+def query(q, config, limit=5, page=1):
+    total_count = 0
+    response = {"q": q, "next": None, "previous": None, "count": None, "results": []}
     for x in config:
         or_condition = Q()
         app_name = x["app_name"].lower()
@@ -14,18 +15,33 @@ def query(q, config):
         ).model_class()
         for search_field in x["search_fields"]:
             or_condition.add(Q(**{f"{search_field}__icontains": q}), Q.OR)
-        for obj in model.objects.filter(or_condition).distinct():
-            counter += 1
-            item = {
-                "id": obj.id,
-                "kind": model_name,
-                "app_name": app_name,
-                "label": obj.__str__(),
-            }
-            try:
-                item["url"] = obj.get_absolute_url()
-            except AttributeError:
-                item["url"] = None
-            response["results"].append(item)
-    response["count"] = counter
+        qs = model.objects.filter(or_condition).distinct()
+        total_count += qs.count()
+        p = Paginator(model.objects.filter(or_condition).distinct(), limit)
+        next_page = False
+        try:
+            p.page(page)
+            has_objects = True
+        except EmptyPage:
+            has_objects = False
+        if has_objects:
+            if p.page(page).has_next:
+                next_page = True
+            for obj in p.page(page).object_list:
+                item = {
+                    "id": obj.id,
+                    "kind": model_name,
+                    "app_name": app_name,
+                    "label": obj.__str__(),
+                }
+                try:
+                    item["url"] = obj.get_absolute_url()
+                except AttributeError:
+                    item["url"] = None
+                response["results"].append(item)
+    response["count"] = total_count
+    if next_page:
+        response["next"] = page + 1
+    if page > 1:
+        response["previous"] = page - 1
     return response

--- a/generic_ac/views.py
+++ b/generic_ac/views.py
@@ -23,7 +23,7 @@ def generic_ac_view(request):
                 config.append(x)
     else:
         config = GENERIC_AC_CONFIG
-    data = query(q, config, limit=limit, page=page)
+    data = query(request, q, config, limit=limit, page=page)
     if only_those:
         data["filter_on"] = only_those
     else:

--- a/generic_ac/views.py
+++ b/generic_ac/views.py
@@ -8,6 +8,14 @@ GENERIC_AC_CONFIG = getattr(settings, "GENERIC_AC_CONFIG")
 def generic_ac_view(request):
     config = []
     q = request.GET.get("q") or ""
+    try:
+        limit = int(request.GET.get("limit", 25))
+    except ValueError:
+        limit = 25
+    try:
+        page = int(request.GET.get("page", 1))
+    except ValueError:
+        page = 1
     only_those = request.GET.getlist("kind")
     if only_those:
         for x in GENERIC_AC_CONFIG:
@@ -15,7 +23,7 @@ def generic_ac_view(request):
                 config.append(x)
     else:
         config = GENERIC_AC_CONFIG
-    data = query(q, config)
+    data = query(q, config, limit=limit, page=page)
     if only_those:
         data["filter_on"] = only_those
     else:


### PR DESCRIPTION
* limit param is per class, i.e `/ac/?limit=10&q=boni&page=3` returns 10 object of each class (if they exist)
* ordering is done
  * by class and as defined in `settings.GENERIC_AC_CONFIG` 
  * by object as defined on the model (should be name or ID)

ToDo:
* add some tests