### PR TITLE
feature: added `additional_fields` to ac-config

### DIFF
--- a/djangobaseproject/settings.py
+++ b/djangobaseproject/settings.py
@@ -2,41 +2,43 @@ import os
 import sys
 from pathlib import Path
 
-sys.modules['fontawesome_free'] = __import__('fontawesome-free')
+sys.modules["fontawesome_free"] = __import__("fontawesome-free")
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
-SECRET_KEY = os.environ.get('SECRET_KEY', '1234verysecret')
+SECRET_KEY = os.environ.get("SECRET_KEY", "1234verysecret")
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-if os.environ.get('DEBUG'):
+if os.environ.get("DEBUG"):
     DEBUG = True
 else:
     DEBUG = False
 
-ADD_ALLOWED_HOST = os.environ.get('ALLOWED_HOST', '*')
+ADD_ALLOWED_HOST = os.environ.get("ALLOWED_HOST", "*")
 ALLOWED_HOSTS = [
     "127.0.0.1",
     "0.0.0.0",
     ADD_ALLOWED_HOST,
 ]
 
-if os.environ.get('SQLITE'):
+if os.environ.get("SQLITE"):
     DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': BASE_DIR / 'db.sqlite3',
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
         }
     }
 else:
     DATABASES = {
-        'default': {
-            'ENGINE': os.environ.get('DB_TYP', 'django.contrib.gis.db.backends.postgis'),
-            'NAME': os.environ.get('DB_NAME', 'mmp'),
-            'USER': os.environ.get('DB_USER', 'postgres'),
-            'PASSWORD': os.environ.get('DB_PASSWORD', 'postgres'),
-            'HOST': os.environ.get('DB_HOST', 'localhost'),
-            'PORT': os.environ.get('DB_PORT', '5432')
+        "default": {
+            "ENGINE": os.environ.get(
+                "DB_TYP", "django.contrib.gis.db.backends.postgis"
+            ),
+            "NAME": os.environ.get("DB_NAME", "mmp"),
+            "USER": os.environ.get("DB_USER", "postgres"),
+            "PASSWORD": os.environ.get("DB_PASSWORD", "postgres"),
+            "HOST": os.environ.get("DB_HOST", "localhost"),
+            "PORT": os.environ.get("DB_PORT", "5432"),
         }
     }
 
@@ -45,99 +47,98 @@ SHARED_URL = "https://shared.acdh.oeaw.ac.at/"
 PROJECT_NAME = "djangobaseproject"
 
 
-ACDH_IMPRINT_URL = "https://shared.acdh.oeaw.ac.at/acdh-common-assets/api/imprint.php?serviceID="
+ACDH_IMPRINT_URL = (
+    "https://shared.acdh.oeaw.ac.at/acdh-common-assets/api/imprint.php?serviceID="
+)
 REDMINE_ID = 18716
 
 # Application definition
 
 INSTALLED_APPS = [
-    'dal',
-    'django.contrib.admin',
-    'dal_select2',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.gis',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework_gis',
-    'reversion',
-    'ckeditor',
-    'ckeditor_uploader',
-    'crispy_forms',
-    'floppyforms',
-    'django_filters',
-    'django_tables2',
-    'django_spaghetti',
-    'rest_framework',
-    'mptt',
-    'leaflet',
-    'webpage',
-    'browsing',
-    'charts',
-    'netvis',
-    'vocabs',
-    'infos',
-    'archiv',
-    'fontawesome_free',
-    'topics',
-    'story_map',
-    'layers',
-    'generic_ac'
+    "dal",
+    "django.contrib.admin",
+    "dal_select2",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.gis",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework_gis",
+    "reversion",
+    "ckeditor",
+    "ckeditor_uploader",
+    "crispy_forms",
+    "floppyforms",
+    "django_filters",
+    "django_tables2",
+    "django_spaghetti",
+    "rest_framework",
+    "mptt",
+    "leaflet",
+    "webpage",
+    "browsing",
+    "charts",
+    "netvis",
+    "vocabs",
+    "infos",
+    "archiv",
+    "fontawesome_free",
+    "topics",
+    "story_map",
+    "layers",
+    "generic_ac",
 ]
 if DEBUG:
-    INSTALLED_APPS.insert(10, 'django_extensions')
+    INSTALLED_APPS.insert(10, "django_extensions")
     # INSTALLED_APPS.insert(11, 'fixture_magic')
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 SPAGHETTI_SAUCE = {
-    'apps': ['archiv', 'topics'],
-    'show_fields': False,
-    'exclude': {'auth': ['user']},
+    "apps": ["archiv", "topics"],
+    "show_fields": False,
+    "exclude": {"auth": ["user"]},
 }
-AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend', )
+AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+    "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ),
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
-    'DEFAULT_PAGINATION_CLASS':
-        'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 50,
-    'DEFAULT_FILTER_BACKENDS': [
-        'django_filters.rest_framework.DjangoFilterBackend'
-    ]
+    "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "PAGE_SIZE": 50,
+    "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
 }
 
 MIDDLEWARE = [
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'reversion.middleware.RevisionMiddleware',
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "reversion.middleware.RevisionMiddleware",
 ]
 
-ROOT_URLCONF = 'djangobaseproject.urls'
+ROOT_URLCONF = "djangobaseproject.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'webpage.webpage_content_processors.installed_apps',
-                'webpage.webpage_content_processors.is_dev_version',
-                'webpage.webpage_content_processors.get_db_name',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "webpage.webpage_content_processors.installed_apps",
+                "webpage.webpage_content_processors.is_dev_version",
+                "webpage.webpage_content_processors.get_db_name",
                 "webpage.webpage_content_processors.shared_url",
                 "webpage.webpage_content_processors.my_app_name",
             ],
@@ -145,23 +146,23 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'djangobaseproject.wsgi.application'
+WSGI_APPLICATION = "djangobaseproject.wsgi.application"
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -169,9 +170,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = 'en'
+LANGUAGE_CODE = "en"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -183,21 +184,21 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles/')
-STATIC_URL = '/static/'
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
-MEDIA_URL = '/media/'
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles/")
+STATIC_URL = "/static/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media/")
+MEDIA_URL = "/media/"
 
 ARCHE_SETTINGS = {
-    'project_name': ROOT_URLCONF.split('.')[0],
-    'base_url': "https://id.acdh.oeaw.ac.at/{}".format(ROOT_URLCONF.split('.')[0])
+    "project_name": ROOT_URLCONF.split(".")[0],
+    "base_url": "https://id.acdh.oeaw.ac.at/{}".format(ROOT_URLCONF.split(".")[0]),
 }
 
-VOCABS_DEFAULT_PEFIX = os.environ.get('VOCABS_DEFAULT_PEFIX', 'mmp')
+VOCABS_DEFAULT_PEFIX = os.environ.get("VOCABS_DEFAULT_PEFIX", "mmp")
 VOCABS_SETTINGS = {
-    'default_prefix': VOCABS_DEFAULT_PEFIX,
-    'default_ns': f"http://www.vocabs/{VOCABS_DEFAULT_PEFIX}/",
-    'default_lang': os.environ.get('VOCABS_DEFAULT_LANG', 'en'),
+    "default_prefix": VOCABS_DEFAULT_PEFIX,
+    "default_ns": f"http://www.vocabs/{VOCABS_DEFAULT_PEFIX}/",
+    "default_lang": os.environ.get("VOCABS_DEFAULT_LANG", "en"),
 }
 
 
@@ -206,10 +207,10 @@ SERIALIZATION_MODULES = {
 }
 
 LEAFLET_CONFIG = {
-    'DEFAULT_CENTER': (40, 10),
-    'DEFAULT_ZOOM': 4,
-    'MIN_ZOOM': 3,
-    'OVERLAYS': []
+    "DEFAULT_CENTER": (40, 10),
+    "DEFAULT_ZOOM": 4,
+    "MIN_ZOOM": 3,
+    "OVERLAYS": [],
 }
 
 # default empty choice label = '-----'; if set to None it is removed as option
@@ -219,43 +220,118 @@ CKEDITOR_UPLOAD_PATH = "uploads/"
 
 
 CKEDITOR_CONFIGS = {
-    'default': {
+    "default": {
         # 'skin': 'moono',
         # 'skin': 'office2013',
-        'toolbar_Basic': [
-            ['Source', '-', 'Bold', 'Italic']
+        "toolbar_Basic": [["Source", "-", "Bold", "Italic"]],
+        "toolbar_YourCustomToolbarConfig": [
+            {
+                "name": "document",
+                "items": [
+                    "Source",
+                    "-",
+                    "Save",
+                    "NewPage",
+                    "Preview",
+                    "Print",
+                    "-",
+                    "Templates",
+                ],
+            },
+            {
+                "name": "clipboard",
+                "items": [
+                    "Cut",
+                    "Copy",
+                    "Paste",
+                    "PasteText",
+                    "PasteFromWord",
+                    "-",
+                    "Undo",
+                    "Redo",
+                ],
+            },
+            {"name": "editing", "items": ["Find", "Replace", "-", "SelectAll"]},
+            {
+                "name": "forms",
+                "items": [
+                    "Form",
+                    "Checkbox",
+                    "Radio",
+                    "TextField",
+                    "Textarea",
+                    "Select",
+                    "Button",
+                    "ImageButton",
+                    "HiddenField",
+                ],
+            },
+            "/",
+            {
+                "name": "basicstyles",
+                "items": [
+                    "Bold",
+                    "Italic",
+                    "Underline",
+                    "Strike",
+                    "Subscript",
+                    "Superscript",
+                    "-",
+                    "RemoveFormat",
+                ],
+            },
+            {
+                "name": "paragraph",
+                "items": [
+                    "NumberedList",
+                    "BulletedList",
+                    "-",
+                    "Outdent",
+                    "Indent",
+                    "-",
+                    "Blockquote",
+                    "CreateDiv",
+                    "-",
+                    "JustifyLeft",
+                    "JustifyCenter",
+                    "JustifyRight",
+                    "JustifyBlock",
+                    "-",
+                    "BidiLtr",
+                    "BidiRtl",
+                    "Language",
+                ],
+            },
+            {"name": "links", "items": ["Link", "Unlink", "Anchor"]},
+            {
+                "name": "insert",
+                "items": [
+                    "Image",
+                    "Flash",
+                    "Table",
+                    "HorizontalRule",
+                    "Smiley",
+                    "SpecialChar",
+                    "PageBreak",
+                    "Iframe",
+                ],
+            },
+            "/",
+            {"name": "styles", "items": ["Styles", "Format", "Font", "FontSize"]},
+            {"name": "colors", "items": ["TextColor", "BGColor"]},
+            {"name": "tools", "items": ["Maximize", "ShowBlocks"]},
+            {"name": "about", "items": ["About"]},
+            "/",  # put this to force next toolbar on new line
+            {
+                "name": "yourcustomtools",
+                "items": [
+                    # put the name of your editor.ui.addButton here
+                    "Preview",
+                    "Maximize",
+                ],
+            },
         ],
-        'toolbar_YourCustomToolbarConfig': [
-            {'name': 'document', 'items': ['Source', '-', 'Save', 'NewPage', 'Preview', 'Print', '-', 'Templates']},
-            {'name': 'clipboard', 'items': ['Cut', 'Copy', 'Paste', 'PasteText', 'PasteFromWord', '-', 'Undo', 'Redo']},
-            {'name': 'editing', 'items': ['Find', 'Replace', '-', 'SelectAll']},
-            {'name': 'forms',
-             'items': ['Form', 'Checkbox', 'Radio', 'TextField', 'Textarea', 'Select', 'Button', 'ImageButton',
-                       'HiddenField']},
-            '/',
-            {'name': 'basicstyles',
-             'items': ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', '-', 'RemoveFormat']},
-            {'name': 'paragraph',
-             'items': ['NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote', 'CreateDiv', '-',
-                       'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-', 'BidiLtr', 'BidiRtl',
-                       'Language']},
-            {'name': 'links', 'items': ['Link', 'Unlink', 'Anchor']},
-            {'name': 'insert',
-             'items': ['Image', 'Flash', 'Table', 'HorizontalRule', 'Smiley', 'SpecialChar', 'PageBreak', 'Iframe']},
-            '/',
-            {'name': 'styles', 'items': ['Styles', 'Format', 'Font', 'FontSize']},
-            {'name': 'colors', 'items': ['TextColor', 'BGColor']},
-            {'name': 'tools', 'items': ['Maximize', 'ShowBlocks']},
-            {'name': 'about', 'items': ['About']},
-            '/',  # put this to force next toolbar on new line
-            {'name': 'yourcustomtools', 'items': [
-                # put the name of your editor.ui.addButton here
-                'Preview',
-                'Maximize',
-
-            ]},
-        ],
-        'toolbar': 'YourCustomToolbarConfig',  # put selected toolbar config here
+        "toolbar": "YourCustomToolbarConfig",  # put selected toolbar config here
         # 'toolbarGroups': [{ 'name': 'document', 'groups': [ 'mode', 'document', 'doctools' ] }],
         # 'height': 291,
         # 'width': '100%',
@@ -263,23 +339,25 @@ CKEDITOR_CONFIGS = {
         # 'filebrowserWindowWidth': 940,
         # 'toolbarCanCollapse': True,
         # 'mathJaxLib': '//cdn.mathjax.org/mathjax/2.2-latest/MathJax.js?config=TeX-AMS_HTML',
-        'tabSpaces': 4,
-        'extraPlugins': ','.join([
-            'uploadimage',  # the upload image feature
-            # your extra plugins here
-            'div',
-            'autolink',
-            'autoembed',
-            'embedsemantic',
-            'autogrow',
-            # 'devtools',
-            'widget',
-            'lineutils',
-            'clipboard',
-            'dialog',
-            'dialogui',
-            'elementspath'
-        ]),
+        "tabSpaces": 4,
+        "extraPlugins": ",".join(
+            [
+                "uploadimage",  # the upload image feature
+                # your extra plugins here
+                "div",
+                "autolink",
+                "autoembed",
+                "embedsemantic",
+                "autogrow",
+                # 'devtools',
+                "widget",
+                "lineutils",
+                "clipboard",
+                "dialog",
+                "dialogui",
+                "elementspath",
+            ]
+        ),
     }
 }
 
@@ -287,58 +365,56 @@ CKEDITOR_CONFIGS = {
 GENERIC_AC_CONFIG = [
     {
         "app_name": "archiv",
-        "model_name": 'autor',
+        "model_name": "autor",
         "search_fields": [
-            'name',
-            'name_lat',
-            'name_en',
-            'name_fr',
-            'name_it',
-            'name_gr',
-        ]
-    },
-    {
-        "app_name": "archiv",
-        "model_name": 'ort',
-        "search_fields": [
-            'name',
-            'name_antik',
-            'name_de',
-            'name_fr',
-            'name_it',
-            'name_gr',
-        ]
-    },
-    {
-        "app_name": "archiv",
-        "model_name": 'text',
-        "search_fields": [
-            'title'
-        ]
-    },
-    {
-        "app_name": "archiv",
-        "model_name": 'stelle',
-        "search_fields": [
-            'zitat',
-            'text__title'
-        ]
-    },
-    {
-        "app_name": 'archiv',
-        "model_name": 'keyword',
-        "search_fields": [
-            'stichwort',
-            'wurzel',
-            'varianten',
+            "name",
+            "name_lat",
+            "name_en",
+            "name_fr",
+            "name_it",
+            "name_gr",
         ],
-        "meta_field": "art"
     },
     {
-        "app_name": 'archiv',
-        "model_name": 'usecase',
+        "app_name": "archiv",
+        "model_name": "ort",
         "search_fields": [
-            'title',
-        ]
+            "name",
+            "name_antik",
+            "name_de",
+            "name_fr",
+            "name_it",
+            "name_gr",
+        ],
+        "additional_fields": {
+            "art": {"lookup": "art", "label": "Type of Place"},
+            "kategorie": {"lookup": "kategorie", "label": "Category of Place"},
+        },
+    },
+    {"app_name": "archiv", "model_name": "text", "search_fields": ["title"]},
+    {
+        "app_name": "archiv",
+        "model_name": "stelle",
+        "search_fields": ["zitat", "text__title"],
+        "additional_fields": {
+            "text": {"lookup": "text", "label": "Text"},
+        },
+    },
+    {
+        "app_name": "archiv",
+        "model_name": "keyword",
+        "search_fields": [
+            "stichwort",
+            "wurzel",
+            "varianten",
+        ],
+        "additional_fields": {"art": {"lookup": "art", "label": "Type of Keyword"}},
+    },
+    {
+        "app_name": "archiv",
+        "model_name": "usecase",
+        "search_fields": [
+            "title",
+        ],
     },
 ]


### PR DESCRIPTION
* return a dict with label, data keys
* Label, and Key can be set to whatever fits best in the ac-config; here they match the field names
* only works for FK and simple fields, NOT FOR M2M

example response:
```JSON
{
    "q": "paris",
    "page_size": 25,
    "next": null,
    "previous": null,
    "count": 1,
    "results": [
        {
            "id": 140,
            "additional_fields": {
                "art": {
                    "label": "Type of Place",
                    "data": "Ort"
                },
                "kategorie": {
                    "label": "Category of Place",
                    "data": "main place"
                }
            },
            "kind": "ort",
            "app_name": "archiv",
            "label": "Paris",
            "url": "127.0.0.1:8000/archiv/ort/detail/140"
        }
    ],
    "filter_on": [
        "ort"
    ]
}
```
