### PR TITLE
chore: rename autocomplete additional fields, omit label

### DIFF
--- a/djangobaseproject/settings.py
+++ b/djangobaseproject/settings.py
@@ -387,17 +387,26 @@ GENERIC_AC_CONFIG = [
             "name_gr",
         ],
         "additional_fields": {
-            "art": {"lookup": "art", "label": "Type of Place"},
-            "kategorie": {"lookup": "kategorie", "label": "Category of Place"},
+            "type": {"lookup": "art", "label": None},
+            "category": {"lookup": "kategorie", "label": None},
         },
     },
-    {"app_name": "archiv", "model_name": "text", "search_fields": ["title"]},
+    {
+        "app_name": "archiv",
+        "model_name": "text",
+        "search_fields": [
+            "title"
+        ]
+    },
     {
         "app_name": "archiv",
         "model_name": "stelle",
-        "search_fields": ["zitat", "text__title"],
+        "search_fields": [
+            "zitat",
+            "text__title"
+        ],
         "additional_fields": {
-            "text": {"lookup": "text", "label": "Text"},
+            "text": {"lookup": "text", "label": None},
         },
     },
     {
@@ -408,7 +417,9 @@ GENERIC_AC_CONFIG = [
             "wurzel",
             "varianten",
         ],
-        "additional_fields": {"art": {"lookup": "art", "label": "Type of Keyword"}},
+        "additional_fields": {
+            "type": {"lookup": "art", "label": None}
+        },
     },
     {
         "app_name": "archiv",


### PR DESCRIPTION
this renames the additional autocomplete fields to english keys, and omits the label which is not necessary for the frontend, but not entirely sure if this is used in a template somewhere elseß