### PR TITLE
docs: change field helptext for passage.places

### DIFF
--- a/archiv/models.py
+++ b/archiv/models.py
@@ -1025,7 +1025,7 @@ class Stelle(models.Model):
         related_name='rvn_stelle_ort_ort',
         blank=True,
         verbose_name="Place",
-        help_text="Place of composition",
+        help_text="Places mentioned in the passage",
     ).set_extra(
         is_public=True,
         arche_prop="hasSpatialCoverage"


### PR DESCRIPTION
afaiu passage.places refers to places mentioned in the textpassage, while text.places refers to places of composition (where the text was produced).

this changes the field help text accordingly.