### PR TITLE
fix: use "autor" as resource kind for author nodes in graph

### DIFF
--- a/archiv/endpoint_views.py
+++ b/archiv/endpoint_views.py
@@ -151,7 +151,7 @@ class KeyWordAuthorEndpoint(ListView):
                 node = {
                     "key": f"autor_{x.id}",
                     "id": x.id,
-                    "kind": "author",
+                    "kind": "autor",
                     "label": f"{x}",
                 }
                 data["nodes"].append(node)


### PR DESCRIPTION
to match other endpoints which return entity `kind` (e.g. the autocomplete endpoints)