### PR TITLE
feat: allow sorting passages by date of composition

### DIFF
--- a/archiv/api_views.py
+++ b/archiv/api_views.py
@@ -177,6 +177,7 @@ class StelleViewSet(viewsets.ModelViewSet):
         OrderingFilter
     ]
     filter_class = StelleListFilter
+    ordering_fields = [field.name for field in Stelle._meta.get_fields()] + ["text__not_before", "text__not_after"]
 
 
 class TextViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
this allows sorting passages by date of composition (`text__not_before` and `text__not_after`).

note that sorting on nested fields requires those fields to be listed explicitly.