### PR TITLE
fix: author-keyword edges should have key, not id

### DIFF
--- a/archiv/endpoint_views.py
+++ b/archiv/endpoint_views.py
@@ -163,7 +163,7 @@ class KeyWordAuthorEndpoint(ListView):
                     if kw_id in node_ids:
                         data["edges"].append(
                             {
-                                "id": f"autor_{x.id}__keyword_{e.id}",
+                                "key": f"autor_{x.id}__keyword_{e.id}",
                                 "source": f"autor_{x.id}",
                                 "target": kw_id,
                             }


### PR DESCRIPTION
keyword-keyword edges in the graph have a `key` field, but author-keyword edges have an `id` field.

this changes author-keyword edges to use `key`s as well.